### PR TITLE
Fix incorrect paths in MANIFEST ClassPath of the agent for Windows

### DIFF
--- a/plugin/src/main/java/org/crsh/visualvm/CrashSwingController.java
+++ b/plugin/src/main/java/org/crsh/visualvm/CrashSwingController.java
@@ -180,7 +180,13 @@ public class CrashSwingController {
     // Build rmanifest string
     StringBuilder buffer = new StringBuilder();
     for (String path : findDependencies(new File(sb.toString()))) {
-      buffer.append(path);
+      // prepend the separator if does not exist (needed for Windows)
+      if(!path.startsWith(separator)) {
+        buffer.append(separator + path);
+      } else {
+        buffer.append(path);
+      }
+
       buffer.append(' ');
     }
 


### PR DESCRIPTION
This issue prevents from attaching to a JVM on Windows.
